### PR TITLE
Add INTERNET permission for network access

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Allow the application to access the network in all build variants -->
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="fitgymtrack_flutter"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- add network permission in `AndroidManifest.xml` so release builds can access internet

## Testing
- `dart format android/app/src/main/AndroidManifest.xml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405ad1c6a483338489e72478f62d44