### PR TITLE
Add ACCESS_NETWORK_STATE permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Allow the application to access the network in all build variants -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:label="fitgymtrack_flutter"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- update AndroidManifest to allow network state checks

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f6f1bf48333b9dd96a17e9ff9ef