### PR TITLE
Fix AndroidManifest configuration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,9 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.fitgymtrack_flutter">
     <!-- Allow the application to access the network in all build variants -->
     <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="fitgymtrack_flutter"
-        android:name="${applicationName}"
+        android:name="io.flutter.app.FlutterApplication"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
## Summary
- specify package in AndroidManifest
- use FlutterApplication for android:name

## Testing
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f39de088333a2a645c3a9d6aa36